### PR TITLE
Fix: Avoid error when value is null

### DIFF
--- a/src/jsonToZod.ts
+++ b/src/jsonToZod.ts
@@ -17,6 +17,9 @@ export const jsonToZod = (
       case "boolean":
         return "z.boolean()";
       case "object":
+        if(obj === null){
+          return z.null();
+        }
         if (seen.find((_obj) => Object.is(_obj, obj))) {
           throw "Circular objects are not supported";
         }


### PR DESCRIPTION
Previously, it was threated as an object and threw Errors:
TypeError: Cannot convert undefined or null to object