### PR TITLE
fix: Add quotes to object keys, in case of invalid symbols

### DIFF
--- a/src/jsonToZod.ts
+++ b/src/jsonToZod.ts
@@ -41,7 +41,7 @@ export const jsonToZod = (
           }
         }
         return `z.object({${Object.entries(obj).map(
-          ([k, v]) => `${k}:${parse(v, seen)}`
+          ([k, v]) => `'${k}':${parse(v, seen)}`
         )}})`;
       case "undefined":
         return "z.undefined()";


### PR DESCRIPTION
Keys like a-2 would break the generated code.