### PR TITLE
Add option to type tuples correctly

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Options:
   -  --source/-s [source file name]
   -  --target/-t [(optional) target file name]
   -  --name/-n [(optional) schema name in output]
+  -  --convertTuples/-c [(optional) handle tuples correctly]
 
 ### Programmatic
 ```typescript
@@ -26,4 +27,21 @@ console.log(result)
 ### Expected output:
 ```
 const schema = z.object({hello: z.string()});
+```
+
+### Handling Tuples
+You can use the `convertTuples` option to handle tuples correctly.
+
+```typescript
+import { jsonToZod } from "json-to-zod"
+
+const myTuple = [1, 'some string']
+
+const result = jsonToZod(myTuple, "schema", false, true)
+
+console.log(result)
+```
+### Expected output:
+```
+const schema = z.tuple([z.number(), z.string()]);
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,10 +67,18 @@ if (nameArgumentIndex !== -1) {
     process.exit(1);
   }
 }
+let convertTuplesArgumentIndex = process.argv.indexOf("--convertTuples");
+if (convertTuplesArgumentIndex === -1) {
+  convertTuplesArgumentIndex = process.argv.indexOf("-c");
+}
+let convertTuples: boolean = false;
+if (convertTuplesArgumentIndex !== -1) {
+  convertTuples = true;
+}
 if (targetFilePath) {
   let result: string;
   try {
-    result = jsonToZod(sourceFileData, name, true);
+    result = jsonToZod(sourceFileData, name, true, convertTuples);
   } catch (e) {
     console.error("Failed to parse sourcefile content to Zod schema");
     console.error(e);
@@ -87,7 +95,7 @@ if (targetFilePath) {
 } else {
   let result: string;
   try {
-    result = jsonToZod(sourceFileData, name);
+    result = jsonToZod(sourceFileData, name, false, convertTuples);
   } catch (e) {
     console.error("Failed to parse sourcefile content to Zod schema");
     console.error(e);


### PR DESCRIPTION
Fixes #9

Add option to handle tuples correctly in `jsonToZod` function.

* Add a new argument `convertTuples` to the `jsonToZod` function in `src/jsonToZod.ts`.
* Update the `parse` function in `src/jsonToZod.ts` to handle tuples correctly when `convertTuples` is true.
* Add a new command-line argument `--convertTuples` in `src/cli.ts` to handle tuples.
* Pass the `convertTuples` argument to the `jsonToZod` function in `src/cli.ts`.
* Update the documentation in `readme.md` to mention the `convertTuples` option for handling tuples.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rsinohara/json-to-zod/pull/10?shareId=87acc6bd-1de5-412e-9498-595d942d855d).